### PR TITLE
Add Success Command to not throw an Error Message upon Deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [v1.1.3] - 2022-09-30
+
+### Added
+
+- made compatible with OXID 6.5 series and Symfony Component from version 5.0
+
+## [v1.1.2] - 2020-05-26
+
+### Changed
+
+- improve console output
+
 ## [v1.1.1] - 2020-05-25
 
 ### Fixed
 
 - clear modules in db (shopid)
-
-### Changed
-
-- improve console output
 
 ## [v1.1.0] - 2020-05-22
 

--- a/src/Command/ModuleactivatorCommand.php
+++ b/src/Command/ModuleactivatorCommand.php
@@ -254,6 +254,8 @@ HELP;
             $output->writeLn("<error>No valid YAML data found!</error>");
         }
         $output->writeLn("<info>END module activator shop " . $activateShopId . "</info>");
+
+        return Command::SUCCESS;
     }
 
     /**


### PR DESCRIPTION
Add Success Command after executed Moduleactivator, because for Symfony Components equal and higher Version 5.x return needed. See Issue https://github.com/symfony/symfony/issues/33747 and Documentation https://symfony.com/doc/5.4/console.html#creating-a-command

Notice: Required from OXID eShop Series 6.5 and higher
